### PR TITLE
Add package imports for module name clashes

### DIFF
--- a/src/Control/Monad/Trans/Lift/CallCC.hs
+++ b/src/Control/Monad/Trans/Lift/CallCC.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 -- | Lifting the @callCC@ operation.
 module Control.Monad.Trans.Lift.CallCC
@@ -23,12 +24,12 @@ import qualified Control.Monad.Trans.Maybe         as M
 import qualified Control.Monad.Trans.Reader        as R
 import qualified Control.Monad.Trans.RWS.Lazy      as RWS.Lazy
 import qualified Control.Monad.Trans.RWS.Strict    as RWS.Strict
-import qualified Control.Monad.Trans.RWS.CPS       as RWS.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.RWS.CPS as RWS.CPS
 import qualified Control.Monad.Trans.State.Lazy    as S.Lazy
 import qualified Control.Monad.Trans.State.Strict  as S.Strict
 import qualified Control.Monad.Trans.Writer.Lazy   as W.Lazy
 import qualified Control.Monad.Trans.Writer.Strict as W.Strict
-import qualified Control.Monad.Trans.Writer.CPS    as W.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.Writer.CPS as W.CPS
 
 #if MIN_VERSION_transformers(0,5,3)
 import qualified Control.Monad.Trans.Accum         as Acc

--- a/src/Control/Monad/Trans/Lift/Catch.hs
+++ b/src/Control/Monad/Trans/Lift/Catch.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 -- | Lifting the @catch@ operation.
 module Control.Monad.Trans.Lift.Catch
@@ -22,12 +23,12 @@ import qualified Control.Monad.Trans.Maybe         as M
 import qualified Control.Monad.Trans.Reader        as R
 import qualified Control.Monad.Trans.RWS.Lazy      as RWS.Lazy
 import qualified Control.Monad.Trans.RWS.Strict    as RWS.Strict
-import qualified Control.Monad.Trans.RWS.CPS       as RWS.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.RWS.CPS as RWS.CPS
 import qualified Control.Monad.Trans.State.Lazy    as S.Lazy
 import qualified Control.Monad.Trans.State.Strict  as S.Strict
 import qualified Control.Monad.Trans.Writer.Lazy   as W.Lazy
 import qualified Control.Monad.Trans.Writer.Strict as W.Strict
-import qualified Control.Monad.Trans.Writer.CPS    as W.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.Writer.CPS as W.CPS
 
 #if MIN_VERSION_transformers(0,5,3)
 import qualified Control.Monad.Trans.Accum         as Acc

--- a/src/Control/Monad/Trans/Lift/Local.hs
+++ b/src/Control/Monad/Trans/Lift/Local.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 -- | Lifting the 'local' operation.
 module Control.Monad.Trans.Lift.Local
@@ -22,12 +23,12 @@ import qualified Control.Monad.Trans.Maybe         as M
 import qualified Control.Monad.Trans.Reader        as R
 import qualified Control.Monad.Trans.RWS.Lazy      as RWS.Lazy
 import qualified Control.Monad.Trans.RWS.Strict    as RWS.Strict
-import qualified Control.Monad.Trans.RWS.CPS       as RWS.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.RWS.CPS as RWS.CPS
 import qualified Control.Monad.Trans.State.Lazy    as S.Lazy
 import qualified Control.Monad.Trans.State.Strict  as S.Strict
 import qualified Control.Monad.Trans.Writer.Lazy   as W.Lazy
 import qualified Control.Monad.Trans.Writer.Strict as W.Strict
-import qualified Control.Monad.Trans.Writer.CPS    as W.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.Writer.CPS as W.CPS
 
 #if MIN_VERSION_transformers(0,5,3)
 import qualified Control.Monad.Trans.Accum         as Acc

--- a/src/Control/Monad/Trans/Lift/StT.hs
+++ b/src/Control/Monad/Trans/Lift/StT.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE KindSignatures #-}
 
@@ -12,12 +13,12 @@ import qualified Control.Monad.Trans.Maybe         as M
 import qualified Control.Monad.Trans.Reader        as R
 import qualified Control.Monad.Trans.RWS.Lazy      as RWS.Lazy
 import qualified Control.Monad.Trans.RWS.Strict    as RWS.Strict
-import qualified Control.Monad.Trans.RWS.CPS       as RWS.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.RWS.CPS as RWS.CPS
 import qualified Control.Monad.Trans.State.Lazy    as S.Lazy
 import qualified Control.Monad.Trans.State.Strict  as S.Strict
 import qualified Control.Monad.Trans.Writer.Lazy   as W.Lazy
 import qualified Control.Monad.Trans.Writer.Strict as W.Strict
-import qualified Control.Monad.Trans.Writer.CPS    as W.CPS
+import qualified "writer-cps-transformers" Control.Monad.Trans.Writer.CPS as W.CPS
 
 #if MIN_VERSION_transformers(0,5,3)
 import qualified Control.Monad.Trans.Accum         as Acc


### PR DESCRIPTION
Do you mind adding these package imports, while #7 is being sorted out?

This makes this package usable with `transformers-0.5.6.2` and `writer-cps-transformers-0.1.1.4`, which at the moment seems to be the only option that enables one to use `transformers-0.5.6.2`.